### PR TITLE
cognito variables expect "user_pool_client_id" and "user_pool_domain"

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ To enable Cognito authentication on the Atlantis ALB, specify the following argu
 ```hcl
 alb_authenticate_cognito = {
   user_pool_arn               = "arn:aws:cognito-idp:us-west-2:1234567890:userpool/us-west-2_aBcDeFG"
-  cognito_user_pool_client_id = "clientid123"
-  cognito_user_pool_domain    = "sso.your-corp.com"
+  user_pool_client_id = "clientid123"
+  user_pool_domain    = "sso.your-corp.com"
 }
 ```
 


### PR DESCRIPTION
```
main.tf line 208, in resource "aws_lb_listener" "frontend_https":
 208:           user_pool_domain                    = authenticate_cognito.value["user_pool_domain"]
    |----------------
    | authenticate_cognito.value is object with 3 attributes

The given key does not identify an element in this collection value.
```